### PR TITLE
feat: adjust print layout for A4 landscape

### DIFF
--- a/src/components/print/print.css
+++ b/src/components/print/print.css
@@ -9,10 +9,11 @@
 
   /* Container principal */
   .print-container {
-    width: 100% !important;
+    width: 29.7cm !important;
+    height: 21cm !important;
     max-width: none !important;
     margin: 0 !important;
-    padding: 8mm !important;
+    padding: 5mm !important;
     font-size: 7pt !important;
     line-height: 1.1 !important;
     color: #000 !important;
@@ -185,8 +186,8 @@
 
   /* Margens de página */
   @page {
-    margin: 0.8cm;
-    size: A4;
+    size: A4 landscape;
+    margin: 0;
   }
 
   /* Layouts compactos */
@@ -219,8 +220,8 @@
 /* Estilos para visualização na tela */
 @media screen {
   .print-container {
-    max-width: 21cm;
-    min-height: 29.7cm;
+    max-width: 29.7cm;
+    min-height: 21cm;
     margin: 0 auto;
     background: white;
     box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);

--- a/src/hooks/usePrintGenerator.ts
+++ b/src/hooks/usePrintGenerator.ts
@@ -228,7 +228,7 @@ export const usePrintGenerator = () => {
           ${styles}
           @media print {
             body { margin: 0; padding: 0; }
-            .print-container { margin: 0; padding: 20mm; }
+            .print-container { margin: 0; padding: 5mm; }
           }
         </style>
       `;


### PR DESCRIPTION
## Summary
- switch print page to A4 landscape with zero margins
- size print container for landscape A4 and trim padding
- update screen preview container to landscape dimensions
- sync direct-print padding with updated landscape layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in several files)*

------
https://chatgpt.com/codex/tasks/task_e_68b99011bcc883229ad7408344ac17ce