### PR TITLE
feat: add produto metadata fields

### DIFF
--- a/src/hooks/useSupabaseQueries.ts
+++ b/src/hooks/useSupabaseQueries.ts
@@ -6,8 +6,8 @@ import { Database } from '@/integrations/supabase/types';
 
 // Types
 type Produto = Database['public']['Tables']['produtos']['Row'];
-type ProdutoInsert = Database['public']['Tables']['produtos']['Insert'];
-type ProdutoUpdate = Database['public']['Tables']['produtos']['Update'];
+type ProdutoInsert = Omit<Database['public']['Tables']['produtos']['Insert'], 'preco_medio'>;
+type ProdutoUpdate = Omit<Database['public']['Tables']['produtos']['Update'], 'preco_medio'>;
 
 type Categoria = Database['public']['Tables']['categorias']['Row'];
 type CategoriaInsert = Database['public']['Tables']['categorias']['Insert'];
@@ -51,7 +51,25 @@ export const useProdutos = () => {
       const { data, error } = await supabase
         .from('produtos')
         .select(`
-          *,
+          id,
+          nome,
+          marca,
+          codigo,
+          codigo_interno,
+          ncm_sh,
+          codigo_barras,
+          categoria_id,
+          empresa_id,
+          preco_custo,
+          preco_medio,
+          preco_venda,
+          quantidade,
+          estoque_minimo,
+          data_entrada,
+          status,
+          created_at,
+          updated_at,
+          user_id,
           categoria:categorias(nome)
         `)
         .eq('empresa_id', empresaId)
@@ -75,7 +93,25 @@ export const useProdutoById = (id: string) => {
       const { data, error } = await supabase
         .from('produtos')
         .select(`
-          *,
+          id,
+          nome,
+          marca,
+          codigo,
+          codigo_interno,
+          ncm_sh,
+          codigo_barras,
+          categoria_id,
+          empresa_id,
+          preco_custo,
+          preco_medio,
+          preco_venda,
+          quantidade,
+          estoque_minimo,
+          data_entrada,
+          status,
+          created_at,
+          updated_at,
+          user_id,
           categoria:categorias(nome)
         `)
         .eq('id', id)

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -989,6 +989,9 @@ export type Database = {
         Row: {
           categoria_id: string | null
           codigo: string | null
+          codigo_interno: string | null
+          ncm_sh: string | null
+          codigo_barras: string | null
           created_at: string
           data_entrada: string | null
           empresa_id: string | null
@@ -997,6 +1000,7 @@ export type Database = {
           marca: string | null
           nome: string
           preco_custo: number | null
+          preco_medio: number | null
           preco_venda: number
           quantidade: number
           status: Database["public"]["Enums"]["produto_status"] | null
@@ -1006,6 +1010,9 @@ export type Database = {
         Insert: {
           categoria_id?: string | null
           codigo?: string | null
+          codigo_interno?: string | null
+          ncm_sh?: string | null
+          codigo_barras?: string | null
           created_at?: string
           data_entrada?: string | null
           empresa_id?: string | null
@@ -1014,6 +1021,7 @@ export type Database = {
           marca?: string | null
           nome: string
           preco_custo?: number | null
+          preco_medio?: number | null
           preco_venda: number
           quantidade?: number
           status?: Database["public"]["Enums"]["produto_status"] | null
@@ -1023,6 +1031,9 @@ export type Database = {
         Update: {
           categoria_id?: string | null
           codigo?: string | null
+          codigo_interno?: string | null
+          ncm_sh?: string | null
+          codigo_barras?: string | null
           created_at?: string
           data_entrada?: string | null
           empresa_id?: string | null
@@ -1031,6 +1042,7 @@ export type Database = {
           marca?: string | null
           nome?: string
           preco_custo?: number | null
+          preco_medio?: number | null
           preco_venda?: number
           quantidade?: number
           status?: Database["public"]["Enums"]["produto_status"] | null

--- a/src/pages/InventorySupabase.tsx
+++ b/src/pages/InventorySupabase.tsx
@@ -45,6 +45,9 @@ const InventorySupabase = () => {
     nome: '',
     marca: '',
     codigo: '',
+    codigo_interno: '',
+    ncm_sh: '',
+    codigo_barras: '',
     categoria_id: '',
     preco_custo: '',
     preco_venda: '',
@@ -57,6 +60,9 @@ const InventorySupabase = () => {
     nome: '',
     marca: '',
     codigo: '',
+    codigo_interno: '',
+    ncm_sh: '',
+    codigo_barras: '',
     categoria_id: '',
     preco_custo: '',
     preco_venda: '',
@@ -111,6 +117,9 @@ const InventorySupabase = () => {
         nome: newProduct.nome,
         marca: newProduct.marca || null,
         codigo: newProduct.codigo || null,
+        codigo_interno: newProduct.codigo_interno || null,
+        ncm_sh: newProduct.ncm_sh || null,
+        codigo_barras: newProduct.codigo_barras || null,
         categoria_id: newProduct.categoria_id || null,
         preco_custo: parseFloat(newProduct.preco_custo) || 0,
         preco_venda: parseFloat(newProduct.preco_venda),
@@ -127,6 +136,9 @@ const InventorySupabase = () => {
         nome: '',
         marca: '',
         codigo: '',
+        codigo_interno: '',
+        ncm_sh: '',
+        codigo_barras: '',
         categoria_id: '',
         preco_custo: '',
         preco_venda: '',
@@ -175,6 +187,9 @@ const InventorySupabase = () => {
         nome: editProduct.nome,
         marca: editProduct.marca || null,
         codigo: editProduct.codigo || null,
+        codigo_interno: editProduct.codigo_interno || null,
+        ncm_sh: editProduct.ncm_sh || null,
+        codigo_barras: editProduct.codigo_barras || null,
         categoria_id: editProduct.categoria_id || null,
         preco_custo: parseFloat(editProduct.preco_custo) || 0,
         preco_venda: parseFloat(editProduct.preco_venda),
@@ -191,6 +206,9 @@ const InventorySupabase = () => {
         nome: '',
         marca: '',
         codigo: '',
+        codigo_interno: '',
+        ncm_sh: '',
+        codigo_barras: '',
         categoria_id: '',
         preco_custo: '',
         preco_venda: '',
@@ -373,6 +391,33 @@ const InventorySupabase = () => {
                   />
                 </div>
                 <div>
+                  <Label htmlFor="product-internal-code">Código Interno</Label>
+                  <Input
+                    id="product-internal-code"
+                    value={newProduct.codigo_interno}
+                    onChange={(e) => setNewProduct({ ...newProduct, codigo_interno: e.target.value })}
+                    placeholder="Código interno"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="product-ncm">NCM/SH</Label>
+                  <Input
+                    id="product-ncm"
+                    value={newProduct.ncm_sh}
+                    onChange={(e) => setNewProduct({ ...newProduct, ncm_sh: e.target.value })}
+                    placeholder="NCM/SH"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="product-barcode">Código de Barras</Label>
+                  <Input
+                    id="product-barcode"
+                    value={newProduct.codigo_barras}
+                    onChange={(e) => setNewProduct({ ...newProduct, codigo_barras: e.target.value })}
+                    placeholder="Código de barras"
+                  />
+                </div>
+                <div>
                   <Label htmlFor="product-category">Categoria</Label>
                   <Select value={newProduct.categoria_id} onValueChange={(value) => setNewProduct({ ...newProduct, categoria_id: value })}>
                     <SelectTrigger>
@@ -407,6 +452,16 @@ const InventorySupabase = () => {
                     value={newProduct.preco_venda}
                     onChange={(e) => setNewProduct({ ...newProduct, preco_venda: e.target.value })}
                     placeholder="0.00"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="product-average">Preço Médio</Label>
+                  <Input
+                    id="product-average"
+                    type="number"
+                    step="0.01"
+                    value="0"
+                    readOnly
                   />
                 </div>
                 <div>
@@ -588,6 +643,9 @@ const InventorySupabase = () => {
                                 nome: produto.nome,
                                 marca: produto.marca || '',
                                 codigo: produto.codigo || '',
+                                codigo_interno: produto.codigo_interno || '',
+                                ncm_sh: produto.ncm_sh || '',
+                                codigo_barras: produto.codigo_barras || '',
                                 categoria_id: produto.categoria_id || '',
                                 preco_custo: produto.preco_custo?.toString() || '',
                                 preco_venda: produto.preco_venda?.toString() || '',
@@ -730,6 +788,33 @@ const InventorySupabase = () => {
               />
             </div>
             <div>
+              <Label htmlFor="edit-product-internal-code">Código Interno</Label>
+              <Input
+                id="edit-product-internal-code"
+                value={editProduct.codigo_interno}
+                onChange={(e) => setEditProduct({ ...editProduct, codigo_interno: e.target.value })}
+                placeholder="Código interno"
+              />
+            </div>
+            <div>
+              <Label htmlFor="edit-product-ncm">NCM/SH</Label>
+              <Input
+                id="edit-product-ncm"
+                value={editProduct.ncm_sh}
+                onChange={(e) => setEditProduct({ ...editProduct, ncm_sh: e.target.value })}
+                placeholder="NCM/SH"
+              />
+            </div>
+            <div>
+              <Label htmlFor="edit-product-barcode">Código de Barras</Label>
+              <Input
+                id="edit-product-barcode"
+                value={editProduct.codigo_barras}
+                onChange={(e) => setEditProduct({ ...editProduct, codigo_barras: e.target.value })}
+                placeholder="Código de barras"
+              />
+            </div>
+            <div>
               <Label htmlFor="edit-product-category">Categoria</Label>
               <Select value={editProduct.categoria_id} onValueChange={(value) => setEditProduct({ ...editProduct, categoria_id: value })}>
                 <SelectTrigger>
@@ -764,6 +849,16 @@ const InventorySupabase = () => {
                 value={editProduct.preco_venda}
                 onChange={(e) => setEditProduct({ ...editProduct, preco_venda: e.target.value })}
                 placeholder="0.00"
+              />
+            </div>
+            <div>
+              <Label htmlFor="edit-product-average">Preço Médio</Label>
+              <Input
+                id="edit-product-average"
+                type="number"
+                step="0.01"
+                value={selectedProduct?.preco_medio?.toString() || '0'}
+                readOnly
               />
             </div>
             <div>


### PR DESCRIPTION
## Summary
- extend produto table types with internal code, NCM/SH, barcode and average price
- expose new produto fields in hooks and queries
- capture new produto metadata and show average price in inventory forms

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 127 problems (115 errors, 12 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68ba523543ec83228e2e3992a3c8a79e